### PR TITLE
Update createDomain endpoint

### DIFF
--- a/lib/api/heroku.js
+++ b/lib/api/heroku.js
@@ -20,7 +20,7 @@ module.exports = {
     .get(`apps/${HEROKU_APP_NAME}/domains/${hostname}`)
     .catch((e) => { throw e; }),
   createDomain: (hostname = required('hostname')) => api
-    .post(`apps/${HEROKU_APP_NAME}/domains`, { hostname })
+    .post(`apps/${HEROKU_APP_NAME}/domains`, { hostname, sni_endpoint: null })
     .catch((e) => { throw e; }),
   deleteDomain: (hostname = required('hostname')) => api
     .delete(`apps/${HEROKU_APP_NAME}/domains/${hostname}`)


### PR DESCRIPTION
Heroku error response when execute createDomain request:
`data: { id: 'invalid_params', message: 'Require params: sni_endpoint.' }`

This method require sni_endpoint params with null | Object value.